### PR TITLE
feat: message level policy

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,13 +8,31 @@ image:https://circleci.com/gh/gravitee-io/gravitee-policy-json-xml.svg?style=svg
 image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum", link="https://community.gravitee.io?utm_source=readme", height=20]
 endif::[]
 
-== Phase
+== Phases
+
+=== V3 engine
 
 [cols="2*", options="header"]
 |===
 ^|onRequestContent
 ^|onResponseContent
 
+^.^| X
+^.^| X
+
+|===
+
+=== Jupiter engine
+
+[cols="4*", options="header"]
+|===
+^|onRequest
+^|onResponse
+^|onMessageRequest
+^|onMessageResponse
+
+^.^| X
+^.^| X
 ^.^| X
 ^.^| X
 
@@ -31,7 +49,7 @@ You can configure the policy with the following options:
 |===
 |Property |Required |Description |Type |Default
 
-.^|scope
+.^|scope _(deprecated, v3 only)_
 ^.^|X
 |The execution scope (`request` or `response`).
 ^.^|string

--- a/pom.xml
+++ b/pom.xml
@@ -25,24 +25,30 @@
     <version>1.1.1</version>
     <packaging>jar</packaging>
     <name>Gravitee.io APIM - Policy - JSON to XML Transformation</name>
-    <description>Description of the JSON to XML Transformation  Gravitee Policy</description>
+    <description>Description of the JSON to XML Transformation Gravitee Policy</description>
 
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>17.2</version>
+        <version>20.4</version>
     </parent>
 
     <properties>
-        <gravitee-gateway-buffer.version>3.10.0</gravitee-gateway-buffer.version>
-        <gravitee-bom.version>1.4</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.20.0</gravitee-common.version>
+        <gravitee-bom.version>2.6</gravitee-bom.version>
+        <gravitee-apim-gateway-buffer.version>3.20.0-SNAPSHOT</gravitee-apim-gateway-buffer.version>
+        <gravitee-gateway-api.version>1.46.1</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-common.version>1.27.0</gravitee-common.version>
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
         <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
+        <json.version>20220320</json.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.20.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-node-api.version>1.21.0</gravitee-node-api.version>
+        <gravitee-node.version>1.24.2</gravitee-node.version>
+        <gravitee-plugin.version>1.24.1</gravitee-plugin.version>
+        <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
     </properties>
 
     <dependencyManagement>
@@ -54,6 +60,35 @@
                 <version>${gravitee-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin</artifactId>
+                <version>${gravitee-plugin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.common</groupId>
+                <artifactId>gravitee-common</artifactId>
+                <version>${gravitee-common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node</artifactId>
+                <version>${gravitee-node.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.gateway</groupId>
+                <artifactId>gravitee-gateway-api</artifactId>
+                <version>${gravitee-gateway-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.connector</groupId>
+                <artifactId>gravitee-connector-api</artifactId>
+                <version>${gravitee-connector-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -82,32 +117,33 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>provided</scope>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>${json.version}</version>
         </dependency>
 
         <!-- Test scope -->
         <dependency>
-            <groupId>io.gravitee.gateway</groupId>
-            <artifactId>gravitee-gateway-buffer</artifactId>
-            <version>${gravitee-gateway-buffer.version}</version>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-buffer</artifactId>
+            <version>${gravitee-apim-gateway-buffer.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -119,19 +155,17 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20201115</version>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/src/main/java/io/gravitee/policy/v3/json2xml/JsonToXmlTransformationPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/json2xml/JsonToXmlTransformationPolicyV3.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.v3.json2xml;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.stream.TransformableRequestStreamBuilder;
+import io.gravitee.gateway.api.http.stream.TransformableResponseStreamBuilder;
+import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.stream.exception.TransformationException;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequestContent;
+import io.gravitee.policy.api.annotations.OnResponseContent;
+import io.gravitee.policy.json2xml.configuration.JsonToXmlTransformationPolicyConfiguration;
+import io.gravitee.policy.json2xml.configuration.PolicyScope;
+import io.gravitee.policy.json2xml.transformer.JSONObject;
+import io.gravitee.policy.json2xml.transformer.XML;
+import io.gravitee.policy.json2xml.utils.CharsetHelper;
+import java.nio.charset.Charset;
+import java.util.function.Function;
+
+/**
+ * @author Guillaume Cusnieux (guillaume.cusnieux at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class JsonToXmlTransformationPolicyV3 {
+
+    public static final String UTF8_CHARSET_NAME = "UTF-8";
+    public static final String CONTENT_TYPE = MediaType.APPLICATION_XML + ";charset=" + UTF8_CHARSET_NAME;
+
+    /**
+     * Json to xml transformation configuration
+     */
+    protected final JsonToXmlTransformationPolicyConfiguration configuration;
+
+    public JsonToXmlTransformationPolicyV3(final JsonToXmlTransformationPolicyConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @OnResponseContent
+    public ReadWriteStream onResponseContent(Response response, PolicyChain chain) {
+        if (configuration.getScope() == null || configuration.getScope() == PolicyScope.RESPONSE) {
+            Charset charset = CharsetHelper.extractCharset(response.headers());
+
+            return TransformableResponseStreamBuilder.on(response).chain(chain).contentType(CONTENT_TYPE).transform(map(charset)).build();
+        }
+        return null;
+    }
+
+    @OnRequestContent
+    public ReadWriteStream onRequestContent(Request request, PolicyChain chain) {
+        if (configuration.getScope() == PolicyScope.REQUEST) {
+            Charset charset = CharsetHelper.extractCharset(request.headers());
+
+            return TransformableRequestStreamBuilder.on(request).chain(chain).contentType(CONTENT_TYPE).transform(map(charset)).build();
+        }
+        return null;
+    }
+
+    private Function<Buffer, Buffer> map(Charset charset) {
+        return input -> {
+            try {
+                String encodedPayload = new String(input.toString(charset).getBytes(UTF8_CHARSET_NAME));
+                JSONObject jsonPayload = new JSONObject(encodedPayload);
+                JSONObject jsonPayloadWithRoot = new JSONObject();
+                jsonPayloadWithRoot.append(this.configuration.getRootElement(), jsonPayload);
+                return Buffer.buffer(XML.toString(jsonPayloadWithRoot));
+            } catch (Exception ex) {
+                throw new TransformationException("Unable to transform JSON into XML: " + ex.getMessage(), ex);
+            }
+        };
+    }
+}

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,5 @@ class=io.gravitee.policy.json2xml.JsonToXmlTransformationPolicy
 type=policy
 category=transformation
 icon=json-to-xml.svg
+sync=REQUEST,RESPONSE
+async=MESSAGE_REQUEST,MESSAGE_RESPONSE

--- a/src/test/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicyIntegrationTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.json2xml;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.policy.json2xml.configuration.JsonToXmlTransformationPolicyConfiguration;
+import io.reactivex.observers.TestObserver;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+public class JsonToXmlTransformationPolicyIntegrationTest
+    extends AbstractPolicyTest<JsonToXmlTransformationPolicy, JsonToXmlTransformationPolicyConfiguration> {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        api.setExecutionMode(ExecutionMode.JUPITER);
+    }
+
+    @Test
+    @DisplayName("Should post xml to backend")
+    @DeployApi("/apis/api-pre.json")
+    void shouldPostXmlContentToBackend(WebClient client) {
+        final String input = loadResource("/io/gravitee/policy/json2xml/input.json");
+        final String expected = loadResource("/io/gravitee/policy/json2xml/expected.xml");
+
+        wiremock.stubFor(post("/team").willReturn(ok()));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.post("/test").rxSendBuffer(Buffer.buffer(input)).test();
+
+        awaitTerminalEvent(obs)
+            .assertComplete()
+            .assertValue(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return true;
+                }
+            )
+            .assertNoErrors();
+
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo("/team")).withRequestBody(new EqualToPattern(expected)));
+    }
+
+    @Test
+    @DisplayName("Should get xml from gateway")
+    @DeployApi("/apis/api-post.json")
+    void shouldGetXmlContentFromBackend(WebClient client) {
+        final String expected = loadResource("/io/gravitee/policy/json2xml/expected.xml");
+        final String backendResponse = loadResource("/io/gravitee/policy/json2xml/input.json");
+        wiremock.stubFor(get("/team").willReturn(ok(backendResponse)));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
+
+        awaitTerminalEvent(obs)
+            .assertComplete()
+            .assertValue(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    assertThat(response.bodyAsString()).isEqualTo(expected);
+                    return true;
+                }
+            )
+            .assertNoErrors();
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    private String loadResource(String resource) {
+        try (InputStream is = this.getClass().getResourceAsStream(resource)) {
+            return new String(Objects.requireNonNull(is).readAllBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicyTest.java
@@ -15,36 +15,40 @@
  */
 package io.gravitee.policy.json2xml;
 
+import static io.gravitee.policy.v3.json2xml.JsonToXmlTransformationPolicyV3.CONTENT_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-import io.gravitee.gateway.api.Request;
-import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.api.stream.ReadWriteStream;
-import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.gateway.api.stream.exception.TransformationException;
+import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.Request;
+import io.gravitee.gateway.jupiter.api.context.Response;
+import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
+import io.gravitee.gateway.jupiter.api.message.Message;
 import io.gravitee.policy.json2xml.configuration.JsonToXmlTransformationPolicyConfiguration;
-import io.gravitee.policy.json2xml.configuration.PolicyScope;
-import io.gravitee.reporter.api.http.Metrics;
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
+import io.reactivex.MaybeTransformer;
+import io.reactivex.observers.TestObserver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
+import java.util.Objects;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
 @ExtendWith(MockitoExtension.class)
@@ -56,125 +60,184 @@ class JsonToXmlTransformationPolicyTest {
     private JsonToXmlTransformationPolicyConfiguration configuration;
 
     @Mock
-    private PolicyChain policyChain;
+    private ExecutionContext ctx;
 
-    @Spy
+    @Mock
     private Request request;
 
-    @Spy
+    @Mock
     private Response response;
+
+    @Captor
+    private ArgumentCaptor<MaybeTransformer<Buffer, Buffer>> onBodyCaptor;
+
+    @Captor
+    private ArgumentCaptor<Function<Message, Maybe<Message>>> onMessageCaptor;
 
     @BeforeEach
     public void setUp() {
         cut = new JsonToXmlTransformationPolicy(configuration);
+        lenient().when(ctx.request()).thenReturn(request);
+        lenient().when(ctx.response()).thenReturn(response);
+
+        lenient().when(request.headers()).thenReturn(HttpHeaders.create());
+        lenient().when(response.headers()).thenReturn(HttpHeaders.create());
     }
 
     @Test
-    @DisplayName("Should transform and add header OnRequestContent")
-    public void shouldTransformAndAddHeadersOnRequestContent() throws Exception {
-        String input = loadResource("/io/gravitee/policy/json2xml/input.json");
-        String expected = loadResource("/io/gravitee/policy/json2xml/expected.xml");
+    @DisplayName("Should transform and add header OnRequest")
+    public void shouldTransformAndAddHeadersOnRequest() throws Exception {
+        final String input = loadResource("/io/gravitee/policy/json2xml/input.json");
+        final String expected = loadResource("/io/gravitee/policy/json2xml/expected.xml");
+        final HttpHeaders headers = HttpHeaders.create();
 
-        // Prepare context
-        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(request.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+        when(configuration.getRootElement()).thenReturn("root");
+        when(request.headers()).thenReturn(headers);
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Buffer> bodyObs = ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer(input)))).test();
+
+        bodyObs.assertValue(buffer -> expected.equals(buffer.toString()));
+        verifyHeaders(headers);
+    }
+
+    @Test
+    @DisplayName("Should do nothing when no body OnRequest")
+    public void shouldDoNothingWhenNoBodyOnRequest() {
+        when(request.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Buffer> bodyObs = ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.empty())).test();
+
+        bodyObs.assertNoValues();
+        verify(request, never()).headers();
+    }
+
+    @Test
+    @DisplayName("Should interrupt with failure when bad json OnRequest")
+    public void shouldInterruptWhenBadJsonOnRequest() {
+        when(request.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+        when(request.headers()).thenReturn(HttpHeaders.create());
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Buffer> bodyObs = ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer("Bad Json")))).test();
+
+        bodyObs.assertError(TransformationException.class);
+    }
+
+    @Test
+    @DisplayName("Should transform and add header OnResponse")
+    public void shouldTransformAndAddHeadersOnResponse() throws Exception {
+        final String input = loadResource("/io/gravitee/policy/json2xml/input.json");
+        final String expected = loadResource("/io/gravitee/policy/json2xml/expected.xml");
+        final HttpHeaders headers = HttpHeaders.create();
+
+        when(response.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+        when(configuration.getRootElement()).thenReturn("root");
+        when(response.headers()).thenReturn(headers);
+
+        final TestObserver<Void> obs = cut.onResponse(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Buffer> bodyObs = ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer(input)))).test();
+
+        bodyObs.assertValue(buffer -> expected.equals(buffer.toString()));
+        verifyHeaders(headers);
+    }
+
+    @Test
+    @DisplayName("Should do nothing when no body OnResponse")
+    public void shouldDoNothingWhenNoBodyOnResponse() throws Exception {
+        when(response.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+
+        final TestObserver<Void> obs = cut.onResponse(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Buffer> bodyObs = ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.empty())).test();
+
+        bodyObs.assertNoValues();
+        verify(response, never()).headers();
+    }
+
+    @Test
+    @DisplayName("Should interrupt with failure when bad json OnResponse")
+    public void shouldInterruptWhenBadJsonOnResponse() {
+        when(response.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+        when(response.headers()).thenReturn(HttpHeaders.create());
+
+        final TestObserver<Void> obs = cut.onResponse(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Buffer> bodyObs = ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer("Bad Json")))).test();
+
+        bodyObs.assertError(TransformationException.class);
+    }
+
+    @Test
+    @DisplayName("Should transform OnMessageRequest")
+    public void shouldTransformOnMessageRequest() throws Exception {
+        final String input = loadResource("/io/gravitee/policy/json2xml/input.json");
+        final String expected = loadResource("/io/gravitee/policy/json2xml/expected.xml");
+
+        when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         when(configuration.getRootElement()).thenReturn("root");
         when(request.headers()).thenReturn(HttpHeaders.create());
 
-        final ReadWriteStream result = cut.onRequestContent(request, policyChain);
-        assertThat(result).isNotNull();
-        result.bodyHandler(
-            resultBody -> {
-                assertResultingJsonObjectsAreEquals(expected, resultBody);
+        final TestObserver<Void> obs = cut.onMessageRequest(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Message> bodyObs = onMessageCaptor.getValue().apply(new DefaultMessage(input)).test();
+
+        bodyObs.assertValue(
+            message -> {
+                assertThat(expected.equals(message.content().toString())).isTrue();
+                verifyHeaders(message.headers());
+                return true;
             }
         );
-
-        result.write(Buffer.buffer(input));
-        result.end();
-
-        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
-        assertThat(request.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0)).isEqualTo(JsonToXmlTransformationPolicy.CONTENT_TYPE);
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
-        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
     }
 
     @Test
-    @DisplayName("Should not transform when TransformationException thrown OnRequestContent")
-    public void shouldNotTransformAndAddHeadersOnRequestContent() throws Exception {
-        String input = loadResource("/io/gravitee/policy/json2xml/invalid-input.json");
+    @DisplayName("Should transform OnMessageResponse")
+    public void shouldTransformOnMessageResponse() throws Exception {
+        final String input = loadResource("/io/gravitee/policy/json2xml/input.json");
+        final String expected = loadResource("/io/gravitee/policy/json2xml/expected.xml");
 
-        // Prepare context
-        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
-        when(request.headers()).thenReturn(HttpHeaders.create());
-        when(request.metrics()).thenReturn(Metrics.on(Instant.now().toEpochMilli()).build());
-
-        final ReadWriteStream result = cut.onRequestContent(request, policyChain);
-        assertThat(result).isNotNull();
-
-        result.write(Buffer.buffer(input));
-        result.end();
-
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_TYPE);
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
-        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_LENGTH);
-        assertThat(request.metrics().getMessage()).contains("Unable to transform JSON into XML:");
-        verify(policyChain, times(1)).streamFailWith(any());
-    }
-
-    @Test
-    @DisplayName("Should transform and add header OnResponseContent")
-    public void shouldTransformAndAddHeadersOnResponseContent() throws Exception {
-        String input = loadResource("/io/gravitee/policy/json2xml/input.json");
-        String expected = loadResource("/io/gravitee/policy/json2xml/expected.xml");
-
-        // Prepare context
-        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+        when(response.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         when(configuration.getRootElement()).thenReturn("root");
         when(response.headers()).thenReturn(HttpHeaders.create());
 
-        final ReadWriteStream result = cut.onResponseContent(response, policyChain);
-        assertThat(result).isNotNull();
-        result.bodyHandler(
-            resultBody -> {
-                assertResultingJsonObjectsAreEquals(expected, resultBody);
+        final TestObserver<Void> obs = cut.onMessageResponse(ctx).test();
+        obs.assertNoValues();
+
+        final TestObserver<Message> bodyObs = onMessageCaptor.getValue().apply(new DefaultMessage(input)).test();
+
+        bodyObs.assertValue(
+            message -> {
+                assertThat(expected.equals(message.content().toString())).isTrue();
+                verifyHeaders(message.headers());
+                return true;
             }
         );
-
-        result.write(Buffer.buffer(input));
-        result.end();
-
-        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
-        assertThat(response.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0)).isEqualTo(JsonToXmlTransformationPolicy.CONTENT_TYPE);
-        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
-        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
     }
 
-    @Test
-    @DisplayName("Should not transform when TransformationException thrown OnResponseContent")
-    public void shouldNotTransformAndAddHeadersOnResponseContent() throws Exception {
-        String input = loadResource("/io/gravitee/policy/json2xml/invalid-input.json");
-
-        // Prepare context
-        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
-        when(response.headers()).thenReturn(HttpHeaders.create());
-
-        final ReadWriteStream result = cut.onResponseContent(response, policyChain);
-        assertThat(result).isNotNull();
-
-        result.write(Buffer.buffer(input));
-        result.end();
-
-        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_TYPE);
-        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
-        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_LENGTH);
-        verify(policyChain, times(1)).streamFailWith(any());
-    }
-
-    private void assertResultingJsonObjectsAreEquals(String expected, Object resultBody) {
-        assertThat(resultBody.toString()).isEqualTo(expected);
+    private void verifyHeaders(HttpHeaders headers) {
+        assertThat(headers.names()).contains(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(headers.getAll(HttpHeaderNames.CONTENT_TYPE).get(0)).isEqualTo(CONTENT_TYPE);
+        assertThat(headers.names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(headers.names()).contains(HttpHeaderNames.CONTENT_LENGTH);
     }
 
     private String loadResource(String resource) throws IOException {
-        InputStream is = this.getClass().getResourceAsStream(resource);
-        return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        try (InputStream is = this.getClass().getResourceAsStream(resource)) {
+            return new String(Objects.requireNonNull(is).readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 }

--- a/src/test/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicyV3CompatibilityIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicyV3CompatibilityIntegrationTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.json2xml;
+
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.policy.v3.json2xml.JsonToXmlTransformationPolicyV3IntegrationTest;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class JsonToXmlTransformationPolicyV3CompatibilityIntegrationTest extends JsonToXmlTransformationPolicyV3IntegrationTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+    }
+}

--- a/src/test/java/io/gravitee/policy/json2xml/utils/CharsetHelperTest.java
+++ b/src/test/java/io/gravitee/policy/json2xml/utils/CharsetHelperTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package utils;
+package io.gravitee.policy.json2xml.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/io/gravitee/policy/v3/json2xml/JsonToXmlTransformationPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/v3/json2xml/JsonToXmlTransformationPolicyV3IntegrationTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.v3.json2xml;
+
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.policy.json2xml.JsonToXmlTransformationPolicyIntegrationTest;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class JsonToXmlTransformationPolicyV3IntegrationTest extends JsonToXmlTransformationPolicyIntegrationTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "false");
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        super.configureApi(api);
+        api.setExecutionMode(ExecutionMode.V3);
+    }
+}

--- a/src/test/java/io/gravitee/policy/v3/json2xml/JsonToXmlTransformationPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/json2xml/JsonToXmlTransformationPolicyV3Test.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.v3.json2xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.json2xml.configuration.JsonToXmlTransformationPolicyConfiguration;
+import io.gravitee.policy.json2xml.configuration.PolicyScope;
+import io.gravitee.reporter.api.http.Metrics;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class JsonToXmlTransformationPolicyV3Test {
+
+    private JsonToXmlTransformationPolicyV3 cut;
+
+    @Mock
+    private JsonToXmlTransformationPolicyConfiguration configuration;
+
+    @Mock
+    private PolicyChain policyChain;
+
+    @Spy
+    private Request request;
+
+    @Spy
+    private Response response;
+
+    @BeforeEach
+    public void init() {
+        cut = new JsonToXmlTransformationPolicyV3(configuration);
+    }
+
+    @Test
+    @DisplayName("Should transform and add header OnRequestContent")
+    public void shouldTransformAndAddHeadersOnRequestContent() throws Exception {
+        String input = loadResource("/io/gravitee/policy/json2xml/input.json");
+        String expected = loadResource("/io/gravitee/policy/json2xml/expected.xml");
+
+        // Prepare context
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(configuration.getRootElement()).thenReturn("root");
+        when(request.headers()).thenReturn(HttpHeaders.create());
+
+        final ReadWriteStream result = cut.onRequestContent(request, policyChain);
+        assertThat(result).isNotNull();
+        result.bodyHandler(
+            resultBody -> {
+                assertResultingJsonObjectsAreEquals(expected, resultBody);
+            }
+        );
+
+        result.write(Buffer.buffer(input));
+        result.end();
+
+        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(request.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0)).isEqualTo(JsonToXmlTransformationPolicyV3.CONTENT_TYPE);
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(request.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
+    }
+
+    @Test
+    @DisplayName("Should not transform when TransformationException thrown OnRequestContent")
+    public void shouldNotTransformAndAddHeadersOnRequestContent() throws Exception {
+        String input = loadResource("/io/gravitee/policy/json2xml/invalid-input.json");
+
+        // Prepare context
+        when(configuration.getScope()).thenReturn(PolicyScope.REQUEST);
+        when(request.headers()).thenReturn(HttpHeaders.create());
+        when(request.metrics()).thenReturn(Metrics.on(Instant.now().toEpochMilli()).build());
+
+        final ReadWriteStream result = cut.onRequestContent(request, policyChain);
+        assertThat(result).isNotNull();
+
+        result.write(Buffer.buffer(input));
+        result.end();
+
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(request.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_LENGTH);
+        assertThat(request.metrics().getMessage()).contains("Unable to transform JSON into XML:");
+        verify(policyChain, times(1)).streamFailWith(any());
+    }
+
+    @Test
+    @DisplayName("Should transform and add header OnResponseContent")
+    public void shouldTransformAndAddHeadersOnResponseContent() throws Exception {
+        String input = loadResource("/io/gravitee/policy/json2xml/input.json");
+        String expected = loadResource("/io/gravitee/policy/json2xml/expected.xml");
+
+        // Prepare context
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+        when(configuration.getRootElement()).thenReturn("root");
+        when(response.headers()).thenReturn(HttpHeaders.create());
+
+        final ReadWriteStream result = cut.onResponseContent(response, policyChain);
+        assertThat(result).isNotNull();
+        result.bodyHandler(
+            resultBody -> {
+                assertResultingJsonObjectsAreEquals(expected, resultBody);
+            }
+        );
+
+        result.write(Buffer.buffer(input));
+        result.end();
+
+        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(response.headers().getAll(HttpHeaderNames.CONTENT_TYPE).get(0)).isEqualTo(JsonToXmlTransformationPolicyV3.CONTENT_TYPE);
+        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(response.headers().names()).contains(HttpHeaderNames.CONTENT_LENGTH);
+    }
+
+    @Test
+    @DisplayName("Should not transform when TransformationException thrown OnResponseContent")
+    public void shouldNotTransformAndAddHeadersOnResponseContent() throws Exception {
+        String input = loadResource("/io/gravitee/policy/json2xml/invalid-input.json");
+
+        // Prepare context
+        when(configuration.getScope()).thenReturn(PolicyScope.RESPONSE);
+        when(response.headers()).thenReturn(HttpHeaders.create());
+
+        final ReadWriteStream result = cut.onResponseContent(response, policyChain);
+        assertThat(result).isNotNull();
+
+        result.write(Buffer.buffer(input));
+        result.end();
+
+        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.TRANSFER_ENCODING);
+        assertThat(response.headers().names()).doesNotContain(HttpHeaderNames.CONTENT_LENGTH);
+        verify(policyChain, times(1)).streamFailWith(any());
+    }
+
+    private void assertResultingJsonObjectsAreEquals(String expected, Object resultBody) {
+        assertThat(resultBody.toString()).isEqualTo(expected);
+    }
+
+    private String loadResource(String resource) throws IOException {
+        InputStream is = this.getClass().getResourceAsStream(resource);
+        return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/resources/apis/api-post.json
+++ b/src/test/resources/apis/api-post.json
@@ -1,0 +1,44 @@
+{
+  "id": "my-api-post",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+      ],
+      "post": [
+        {
+          "name": "Json to XML",
+          "description": "",
+          "enabled": true,
+          "policy": "json-xml",
+          "configuration": {
+            "scope": "RESPONSE"
+          }
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/src/test/resources/apis/api-pre.json
+++ b/src/test/resources/apis/api-pre.json
@@ -1,0 +1,44 @@
+{
+  "id": "my-api-get",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Json to XML",
+          "description": "",
+          "enabled": true,
+          "policy": "json-xml",
+          "configuration": {
+            "scope": "REQUEST"
+          }
+        }
+      ],
+      "post": [
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <!-- Strictly speaking, the level attribute is not necessary since -->
+    <!-- the level of the root level is set to DEBUG by default.       -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8403

**Description**

Add support for running the policy on messages.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0-8403-policy-message-level-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-xml/1.2.0-8403-policy-message-level-SNAPSHOT/gravitee-policy-json-xml-1.2.0-8403-policy-message-level-SNAPSHOT.zip)
  <!-- Version placeholder end -->
