### PR TITLE
APIM-98 interrupt execution chain when any json transformation errors occurred

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -74,12 +74,36 @@ You can configure the policy with the following options:
 
 == Errors
 
-=== HTTP status code
+=== V3 engine
 
 |===
-|Code |Message
+|Code | Description
 
 .^| ```500```
 | The transformation cannot be executed properly
+
+|===
+
+=== Jupiter engine
+
+|===
+|Phase | Code | Error template key | Description
+
+.^| onRequest
+| ```400```
+| JSON_INVALID_PAYLOAD
+| Request payload cannot be transformed properly to XML
+.^| onResponse
+| ```500```
+| JSON_INVALID_PAYLOAD
+| Response payload cannot be transformed properly to XML
+.^| onMessageRequest
+| ```400```
+| JSON_INVALID_MESSAGE_PAYLOAD
+| Incoming message cannot be transformed properly to XML
+.^| onMessageResponse
+| ```500```
+| JSON_INVALID_MESSAGE_PAYLOAD
+| Outgoing message cannot be transformed properly to XML
 
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -16,13 +16,13 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-json-xml</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-apim-98-better-message-error-handling-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Gravitee.io APIM - Policy - JSON to XML Transformation</name>
     <description>Description of the JSON to XML Transformation Gravitee Policy</description>
@@ -34,8 +34,8 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>2.6</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.46.1</gravitee-gateway-api.version>
+        <gravitee-bom.version>2.7</gravitee-bom.version>
+        <gravitee-gateway-api.version>1.48.0-alpha.2</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>

--- a/src/test/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicyV3CompatibilityIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicyV3CompatibilityIntegrationTest.java
@@ -15,10 +15,19 @@
  */
 package io.gravitee.policy.json2xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.policy.v3.json2xml.JsonToXmlTransformationPolicyV3IntegrationTest;
+import io.reactivex.observers.TestObserver;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -30,5 +39,23 @@ public class JsonToXmlTransformationPolicyV3CompatibilityIntegrationTest extends
     protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
         super.configureGateway(gatewayConfigurationBuilder);
         gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+    }
+
+    @Test
+    @DisplayName("Should return Bad Request when posting invalid json to gateway")
+    @DeployApi("/apis/api-pre.json")
+    void shouldReturnBadRequestWhenPostingInvalidJsonToGateway(WebClient client) {
+        final String input = loadResource("/io/gravitee/policy/json2xml/invalid-input.json");
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.post("/test").rxSendBuffer(Buffer.buffer(input)).test();
+
+        awaitTerminalEvent(obs)
+            .assertValue(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(500);
+                    return true;
+                }
+            )
+            .assertNoErrors();
     }
 }


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-98

## Description

 Interrupt execution chain when any json transformation errors occurred

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.1-apim-98-better-message-error-handling-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-xml/1.2.1-apim-98-better-message-error-handling-SNAPSHOT/gravitee-policy-json-xml-1.2.1-apim-98-better-message-error-handling-SNAPSHOT.zip)
  <!-- Version placeholder end -->
