### PR TITLE
Bump rx java

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/pom.xml
+++ b/pom.xml
@@ -35,17 +35,16 @@
 
     <properties>
         <gravitee-bom.version>2.7</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.48.0-alpha.2</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.0.0-alpha.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.27.0</gravitee-common.version>
+        <gravitee-common.version>2.0.0-alpha.1</gravitee-common.version>
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
         <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
         <json.version>20220320</json.version>
         <gravitee-apim-gateway-tests-sdk.version>3.20.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
-        <gravitee-node-api.version>1.21.0</gravitee-node-api.version>
-        <gravitee-node.version>1.24.2</gravitee-node.version>
+        <gravitee-node.version>2.0.0-alpha.3</gravitee-node.version>
         <gravitee-plugin.version>1.24.1</gravitee-plugin.version>
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
     </properties>

--- a/src/main/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicy.java
+++ b/src/main/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicy.java
@@ -30,8 +30,8 @@ import io.gravitee.policy.json2xml.transformer.JSONObject;
 import io.gravitee.policy.json2xml.transformer.XML;
 import io.gravitee.policy.json2xml.utils.CharsetHelper;
 import io.gravitee.policy.v3.json2xml.JsonToXmlTransformationPolicyV3;
-import io.reactivex.Completable;
-import io.reactivex.Maybe;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -79,7 +79,7 @@ public class JsonToXmlTransformationPolicy extends JsonToXmlTransformationPolicy
         return bodyUpstream
             .flatMap(buffer -> transformToXml(buffer, CharsetHelper.extractCharset(httpHeaders)))
             .doOnSuccess(xmlBuffer -> setContentHeaders(httpHeaders, xmlBuffer))
-            .onErrorResumeNext(
+            .onErrorResumeWith(
                 ctx.interruptBodyWith(
                     new ExecutionFailure(failureHttpCode)
                         .key(INVALID_PAYLOAD_FAILURE_KEY)
@@ -111,7 +111,7 @@ public class JsonToXmlTransformationPolicy extends JsonToXmlTransformationPolicy
         return transformToXml(message.content(), CharsetHelper.extractCharset(httpHeaders))
             .map(message::content)
             .doOnSuccess(xmlMessage -> setContentHeaders(message.headers(), xmlMessage.content()))
-            .onErrorResumeNext(
+            .onErrorResumeWith(
                 ctx.interruptMessageWith(
                     new ExecutionFailure(failureHttpCode)
                         .key(INVALID_MESSAGE_PAYLOAD_FAILURE_KEY)

--- a/src/test/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/json2xml/JsonToXmlTransformationPolicyTest.java
@@ -21,8 +21,6 @@ import static io.gravitee.policy.v3.json2xml.JsonToXmlTransformationPolicyV3.CON
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.api.buffer.Buffer;
@@ -36,11 +34,10 @@ import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
 import io.gravitee.gateway.jupiter.api.message.Message;
 import io.gravitee.gateway.jupiter.core.context.interruption.InterruptionFailureException;
 import io.gravitee.policy.json2xml.configuration.JsonToXmlTransformationPolicyConfiguration;
-import io.reactivex.Completable;
-import io.reactivex.Flowable;
-import io.reactivex.Maybe;
-import io.reactivex.MaybeTransformer;
-import io.reactivex.observers.TestObserver;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.MaybeTransformer;
+import io.reactivex.rxjava3.observers.TestObserver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/io/gravitee/policy/v3/json2xml/JsonToXmlTransformationPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/v3/json2xml/JsonToXmlTransformationPolicyV3IntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.policy.v3.json2xml;
 
+import static io.vertx.core.http.HttpMethod.POST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
@@ -22,10 +23,8 @@ import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuil
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.policy.json2xml.JsonToXmlTransformationPolicyIntegrationTest;
-import io.reactivex.observers.TestObserver;
-import io.vertx.reactivex.core.buffer.Buffer;
-import io.vertx.reactivex.ext.web.client.HttpResponse;
-import io.vertx.reactivex.ext.web.client.WebClient;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -50,18 +49,21 @@ public class JsonToXmlTransformationPolicyV3IntegrationTest extends JsonToXmlTra
     @Test
     @DisplayName("Should return Bad Request when posting invalid json to gateway")
     @DeployApi("/apis/api-pre.json")
-    void shouldReturnBadRequestWhenPostingInvalidJsonToGateway(WebClient client) {
+    void shouldReturnBadRequestWhenPostingInvalidJsonToGateway(HttpClient client) throws InterruptedException {
         final String input = loadResource("/io/gravitee/policy/json2xml/invalid-input.json");
 
-        final TestObserver<HttpResponse<Buffer>> obs = client.post("/test").rxSendBuffer(Buffer.buffer(input)).test();
-
-        awaitTerminalEvent(obs)
-            .assertValue(
+        client
+            .rxRequest(POST, "/test")
+            .flatMap(request -> request.rxSend(Buffer.buffer(input)))
+            .flatMapPublisher(
                 response -> {
                     assertThat(response.statusCode()).isEqualTo(500);
-                    return true;
+                    return response.toFlowable();
                 }
             )
+            .test()
+            .await()
+            .assertComplete()
             .assertNoErrors();
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7990
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-bumpRxJava-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-xml/2.0.0-bumpRxJava-SNAPSHOT/gravitee-policy-json-xml-2.0.0-bumpRxJava-SNAPSHOT.zip)
  <!-- Version placeholder end -->
