### PR TITLE
fix: rename execution phase properties in manifest

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,5 +6,5 @@ class=io.gravitee.policy.json2xml.JsonToXmlTransformationPolicy
 type=policy
 category=transformation
 icon=json-to-xml.svg
-sync=REQUEST,RESPONSE
-async=MESSAGE_REQUEST,MESSAGE_RESPONSE
+proxy=REQUEST,RESPONSE
+message=MESSAGE_REQUEST,MESSAGE_RESPONSE


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1707

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.3-execution-phase-in-manifest-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-xml/2.1.3-execution-phase-in-manifest-SNAPSHOT/gravitee-policy-json-xml-2.1.3-execution-phase-in-manifest-SNAPSHOT.zip)
  <!-- Version placeholder end -->
