### PR TITLE
refactor: clean json-schema

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,23 +1,22 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:json2xml:configuration:JsonToXMLTransformationPolicyConfiguration",
-  "properties" : {
-    "scope" : {
-      "title": "Scope",
-      "description": "Execute policy on <strong>request</strong> or <strong>response</strong> phase.",
-      "type" : "string",
-      "default": "REQUEST",
-      "enum" : [ "REQUEST", "RESPONSE" ]
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+    "properties": {
+        "scope": {
+            "title": "Scope",
+            "description": "Select phase to execute the policy.",
+            "type": "string",
+            "default": "REQUEST",
+            "enum": ["REQUEST", "RESPONSE"]
+        },
+        "rootElement": {
+            "title": "Root element",
+            "description": "Root element name that's enclose content.",
+            "type": "string",
+            "default": "root",
+            "pattern": "^[a-z:_A-Z]+[a-zA-Z0-9:-_]*"
+        }
     },
-    "rootElement" : {
-      "title": "Root element",
-      "description": "Root element name that's enclose content",
-      "type" : "string",
-      "default": "root",
-      "pattern": "^[a-z:_A-Z]+[a-zA-Z0-9:-_]*"
-    }
-  },
-  "required": [
-    "rootElement"
-  ]
+    "required": ["rootElement"]
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2085

Description

clean and validate json schema for v4

Tested with :
https://gravitee-io-labs.github.io/gravitee-schema-form-checker/
https://particles.gravitee.io/?path=/story/components-form-json-schema--string



**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-xml/2.2.0-json-schema-SNAPSHOT/gravitee-policy-json-xml-2.2.0-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
