### PR TITLE
fix: check depth of embedded object and array

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -68,4 +68,4 @@ You can configure the policy with the following options:
 
 === Nested objects
 
-To limit the processing time in case of nested object, a default max depth of nested object has been defined to 1000. This default value can be overriden using the environment variable `gravitee_policy_jsonxml_maxdepth`.
+To limit the processing time in case of nested object, a default max depth of nested object has been defined to 100. This default value can be overriden using the environment variable `gravitee_policy_jsonxml_maxdepth`.

--- a/src/main/java/io/gravitee/policy/json2xml/transformer/JSONTokener.java
+++ b/src/main/java/io/gravitee/policy/json2xml/transformer/JSONTokener.java
@@ -58,7 +58,7 @@ SOFTWARE.
  */
 public class JSONTokener {
 
-    public static final int DEFAULT_MAX_DEPTH = 1000;
+    public static final int DEFAULT_MAX_DEPTH = 100;
     private long character;
     private boolean eof;
     private long index;


### PR DESCRIPTION
**Description**

Decrease the nested object limit to 100 instead of 1000 to be consistent with xml-json policy

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.4-decrease-limit-nested-object-1-1-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-xml/1.1.4-decrease-limit-nested-object-1-1-x-SNAPSHOT/gravitee-policy-json-xml-1.1.4-decrease-limit-nested-object-1-1-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
